### PR TITLE
build: merge Package Versions with Global Package References for build dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,6 @@
 <Project>
 
   <ItemGroup Label="build dependencies">
-    <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
 
   <ItemGroup Label="global package references">
     <!-- enable reproducible builds -->
-    <GlobalPackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="All" />
+    <GlobalPackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="All" Version="1.2.25" />
     <!-- enable source link -->
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <!-- enable automatic versioning -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,6 @@
 <Project>
 
   <ItemGroup Label="build dependencies">
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,5 @@
 <Project>
 
-  <ItemGroup Label="build dependencies">
-    <PackageVersion Include="MinVer" Version="6.0.0" />
-  </ItemGroup>
-
   <ItemGroup Label="nuget dependencies">
     <PackageVersion Include="FlatSharp.Compiler" Version="7.8.0" />
     <PackageVersion Include="FlatSharp.Runtime" Version="7.8.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <!-- enable source link -->
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="8.0.0" />
     <!-- enable automatic versioning -->
-    <GlobalPackageReference Include="MinVer" PrivateAssets="All" />
+    <GlobalPackageReference Include="MinVer" PrivateAssets="All" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <!-- enable reproducible builds -->
     <GlobalPackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="All" Version="1.2.25" />
     <!-- enable source link -->
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="8.0.0" />
     <!-- enable automatic versioning -->
     <GlobalPackageReference Include="MinVer" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
- **build (Directory.Packages.props): add Version to Global Package Reference for DotNet.ReproducibleBuilds**
- **build (Directory.Packages.props): remove Package Version for DotNet.ReproducibleBuilds**
- **build (Directory.Packages.props): add Version to Global Package Reference for Microsoft.SourceLink.GitHub**
- **build (Directory.Packages.props): remove Package Version for Microsoft.SourceLink.GitHub**
- **build (Directory.Packages.props): add Version to Global Package Reference for MinVer**
- **build (Directory.Packages.props): remove Package Version for MinVer**
