### PR TITLE
build: disable FlatSharp Name Normalization

### DIFF
--- a/Unity.Mathematics.Schemas/Unity.Mathematics.Schemas.csproj
+++ b/Unity.Mathematics.Schemas/Unity.Mathematics.Schemas.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="FlatSharp build settings">
-    <FlatSharpNameNormalization>true</FlatSharpNameNormalization>
+    <FlatSharpNameNormalization>false</FlatSharpNameNormalization>
     <FlatSharpNullable>true</FlatSharpNullable>
     <FlatSharpDeserializers>Lazy;Progressive;GreedyMutable</FlatSharpDeserializers>
   </PropertyGroup>

--- a/Unity.Mathematics.Tables.Schemas/Unity.Mathematics.Tables.Schemas.csproj
+++ b/Unity.Mathematics.Tables.Schemas/Unity.Mathematics.Tables.Schemas.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="FlatSharp build settings">
-    <FlatSharpNameNormalization>true</FlatSharpNameNormalization>
+    <FlatSharpNameNormalization>false</FlatSharpNameNormalization>
     <FlatSharpNullable>true</FlatSharpNullable>
     <FlatSharpDeserializers>Lazy;Progressive;GreedyMutable</FlatSharpDeserializers>
   </PropertyGroup>


### PR DESCRIPTION
- **build (Unity.Mathematics.Schemas): set FlatSharpNameNormalization to false**
- **build (Unity.Mathematics.Tables.Schemas): set FlatSharpNameNormalization to false**
