### PR TITLE
build: restrict visibility of FlatSharp-generated code

### DIFF
--- a/Unity.Mathematics.Schemas/Unity.Mathematics.Schemas.csproj
+++ b/Unity.Mathematics.Schemas/Unity.Mathematics.Schemas.csproj
@@ -18,6 +18,7 @@
     <FlatSharpNameNormalization>false</FlatSharpNameNormalization>
     <FlatSharpNullable>true</FlatSharpNullable>
     <FlatSharpDeserializers>Lazy;Progressive;GreedyMutable</FlatSharpDeserializers>
+    <FlatSharpFileVisibility>true</FlatSharpFileVisibility>
   </PropertyGroup>
 
   <ItemGroup Label="packaged files">

--- a/Unity.Mathematics.Tables.Schemas/Unity.Mathematics.Tables.Schemas.csproj
+++ b/Unity.Mathematics.Tables.Schemas/Unity.Mathematics.Tables.Schemas.csproj
@@ -18,6 +18,7 @@
     <FlatSharpNameNormalization>false</FlatSharpNameNormalization>
     <FlatSharpNullable>true</FlatSharpNullable>
     <FlatSharpDeserializers>Lazy;Progressive;GreedyMutable</FlatSharpDeserializers>
+    <FlatSharpFileVisibility>true</FlatSharpFileVisibility>
   </PropertyGroup>
 
   <ItemGroup Label="packaged files">


### PR DESCRIPTION
- **build (Unity.Mathematics.Schemas): set FlatSharpFileVisibility to true**
- **build (Unity.Mathematics.Tables.Schemas): set FlatSharpFileVisibility to true**
