### PR TITLE
build: contain FlatSharp compilation to input files only

### DIFF
--- a/Unity.Mathematics.Schemas/Unity.Mathematics.Schemas.csproj
+++ b/Unity.Mathematics.Schemas/Unity.Mathematics.Schemas.csproj
@@ -18,6 +18,7 @@
     <FlatSharpNameNormalization>false</FlatSharpNameNormalization>
     <FlatSharpNullable>true</FlatSharpNullable>
     <FlatSharpDeserializers>Lazy;Progressive;GreedyMutable</FlatSharpDeserializers>
+    <FlatSharpInputFilesOnly>true</FlatSharpInputFilesOnly>
     <FlatSharpFileVisibility>true</FlatSharpFileVisibility>
   </PropertyGroup>
 

--- a/Unity.Mathematics.Tables.Schemas/Unity.Mathematics.Tables.Schemas.csproj
+++ b/Unity.Mathematics.Tables.Schemas/Unity.Mathematics.Tables.Schemas.csproj
@@ -42,10 +42,7 @@
   </ItemGroup>
 
   <ItemGroup Label="project dependencies">
-    <ProjectReference Include="..\Unity.Mathematics.Schemas\Unity.Mathematics.Schemas.csproj" GeneratePathProperty="true">
-      <IncludeAssets>contentfiles</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </ProjectReference>
+    <ProjectReference Include="..\Unity.Mathematics.Schemas\Unity.Mathematics.Schemas.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Unity.Mathematics.Tables.Schemas/Unity.Mathematics.Tables.Schemas.csproj
+++ b/Unity.Mathematics.Tables.Schemas/Unity.Mathematics.Tables.Schemas.csproj
@@ -18,6 +18,7 @@
     <FlatSharpNameNormalization>false</FlatSharpNameNormalization>
     <FlatSharpNullable>true</FlatSharpNullable>
     <FlatSharpDeserializers>Lazy;Progressive;GreedyMutable</FlatSharpDeserializers>
+    <FlatSharpInputFilesOnly>true</FlatSharpInputFilesOnly>
     <FlatSharpFileVisibility>true</FlatSharpFileVisibility>
   </PropertyGroup>
 


### PR DESCRIPTION
- **build (Unity.Mathematics.Schemas): set FlatSharpInputFilesOnly to true**
- **build (Unity.Mathematics.Tables.Schemas): set FlatSharpInputFilesOnly to true**
- **build (Unity.Mathematics.Tables.Schemas): remove non-functional elements from ProjectReference**
